### PR TITLE
fix: add missing output projection in MultiHeadAttention and optimize training

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ class MultiHeadAttention(nn.Module):
     def __init__(self, n_head, n_embed, context_length):
         super().__init__()
         self.heads = nn.ModuleList([Head(n_embed // n_head, n_embed, context_length) for _ in range(n_head)])
+        self.proj = nn.Linear(n_embed, n_embed)
 
     def forward(self, x):
         """
@@ -653,10 +654,12 @@ class MultiHeadAttention(nn.Module):
         """
         # Concatenate the output of each head along the last dimension (C)
         x = torch.cat([h(x) for h in self.heads], dim=-1)
+        # Apply final linear projection
+        x = self.proj(x)
         return x
 ```
 
-Now that we have defined the MultiHeadAttention class, which combines multiple attention heads, the __init__ method initializes a list of Head instances (a total of n_head), each with a head_size of n_embed // n_head. The forward method applies each attention head to the input x and concatenates their outputs along the last dimension, merging the information learned by each head.
+Now that we have defined the MultiHeadAttention class, which combines multiple attention heads, the __init__ method initializes a list of Head instances (a total of n_head), each with a head_size of n_embed // n_head, along with a final projection layer. The forward method applies each attention head to the input x, concatenates their outputs along the last dimension, and projects them linearly to merge the information learned by each head.
 
 ### Transformer Block
 

--- a/scripts/train_transformer.py
+++ b/scripts/train_transformer.py
@@ -103,6 +103,10 @@ for step in pbar:
         # Backpropagate the loss and update the model parameters.
         optimizer.zero_grad(set_to_none=True)
         loss.backward()
+        
+        # Clip gradients to prevent exploding gradients
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        
         optimizer.step()
 
         # Periodically evaluate the model on training and development data.

--- a/src/models/attention.py
+++ b/src/models/attention.py
@@ -80,6 +80,7 @@ class MultiHeadAttention(nn.Module):
         """
         super().__init__()
         self.heads = nn.ModuleList([Head(n_embed // n_head, n_embed, context_length) for _ in range(n_head)])
+        self.proj = nn.Linear(n_embed, n_embed)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -93,6 +94,8 @@ class MultiHeadAttention(nn.Module):
         """
         # Concatenate the output of each head along the last dimension (C)
         x = torch.cat([h(x) for h in self.heads], dim=-1)
+        # Apply final linear projection
+        x = self.proj(x)
         return x
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR introduces essential structural and stability improvements to the core Transformer architecture, making the tutorial mathematically accurate and robust for students learning to build an LLM from scratch.

**Changes Included:**
- **Mathematical Accuracy in Multi-Head Attention:** Added the missing linear projection layer (`self.proj`) to the `MultiHeadAttention` module in `src/models/attention.py`. Previously, head outputs were only concatenated. According to the *Attention is All You Need* paper, a final linear projection is strictly required to mix the representations from different attention heads before adding the residual connection. This significantly boosts model capacity.
- **Training Loop Stability:** Added `torch.nn.utils.clip_grad_norm_` to the training loop in `scripts/train_transformer.py`. This is a standard optimization in PyTorch that prevents exploding gradients—a very common issue when training deep Transformers.
- **Documentation Alignment:** Updated `README.md` to ensure the theoretical explanation of Multi-Head Attention matches the corrected code, accurately explaining the role of the projection layer to students.

**Why this matters for educators and students:**
By ensuring the core components align perfectly with the original paper, students won't learn "anti-patterns". The addition of gradient clipping will also prevent unexpected `NaN` losses, saving beginners hours of frustrating debugging.
