### PR TITLE
docs CI: deploy via official GitHub Pages Actions (Source=GitHub Acti…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,8 @@
 name: docs
 
-# Build the MkDocs Material site and publish it to GitHub Pages (the gh-pages branch).
-# One-time setup after the first run: repo Settings -> Pages -> Source = "Deploy from a
-# branch" -> branch "gh-pages" / root.
+# Build the MkDocs Material site and publish it via GitHub Pages.
+# Pages "Source" must be set to "GitHub Actions" (Settings -> Pages) — which it already is.
+# No gh-pages branch needed; this uses the official Pages deployment actions.
 
 on:
   push:
@@ -15,21 +15,37 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write          # mkdocs gh-deploy pushes to the gh-pages branch
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install docs dependencies
         run: pip install mkdocs mkdocs-material pymdown-extensions
-      - name: Build (strict) and deploy to gh-pages
-        run: |
-          mkdocs build --strict      # fail fast on broken links / nav
-          mkdocs gh-deploy --force   # build + push to the gh-pages branch
+      - name: Build the site (strict)
+        run: mkdocs build --strict --site-dir ./site
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
…ons)

Use actions/upload-pages-artifact + actions/deploy-pages instead of the gh-pages-branch method, matching the repo's Pages Source setting.