### PR TITLE
fix: multi-GPU (DDP) training hangs in SFT, Reward, DPO

### DIFF
--- a/scripts/train_dpo.py
+++ b/scripts/train_dpo.py
@@ -129,7 +129,9 @@ def main():
                             metrics={"train_loss": loss.item()})
 
     if ctx.is_main:
-        acc, marg = eval_implicit_acc(policy, ref, cfg, ctx)
+        # Unwrap for the final eval: other ranks are already at cleanup(), so a collective on
+        # the DDP-wrapped policy here would hang (NCCL timeout). The periodic eval runs on all ranks.
+        acc, marg = eval_implicit_acc(unwrap(policy), ref, cfg, ctx)
         save_stage_ckpt(cfg.out_ckpt, policy, optimizer, stage=f"dpo_{cfg.loss_type}", cfg=cfg, step=total_steps,
                         metrics={"test_acc": acc, "test_margin": marg})
         print(f"Done DPO[{cfg.loss_type}]. test_acc {acc:.3f} margin {marg:.3f} -> {cfg.out_ckpt}")

--- a/scripts/train_reward.py
+++ b/scripts/train_reward.py
@@ -63,7 +63,10 @@ def main():
 
     backbone = load_backbone_from_ckpt(cfg, cfg.sft_ckpt, ctx.device)
     rm = RewardModel(backbone).to(ctx.device)
-    rm = ddp_wrap(rm, ctx)
+    # find_unused_parameters=True: the reward model uses the backbone's forward_hidden + a
+    # reward head and never its lm_head, so lm_head params get no gradient. Without this flag
+    # DDP errors on the first backward.
+    rm = ddp_wrap(rm, ctx, find_unused_parameters=True)
     optimizer = configure_optimizer(unwrap(rm), cfg.lr, cfg.weight_decay)
 
     import json
@@ -114,7 +117,9 @@ def main():
                             metrics={"train_loss": loss.item()})
 
     if ctx.is_main:
-        acc, marg = eval_accuracy(rm, cfg, ctx)
+        # Unwrap for the final eval: other ranks are already at cleanup(), so a collective on
+        # the DDP-wrapped model here would hang (NCCL timeout). The periodic eval runs on all ranks.
+        acc, marg = eval_accuracy(unwrap(rm), cfg, ctx)
         save_stage_ckpt(cfg.out_ckpt, rm, optimizer, stage="reward", cfg=cfg, step=total_steps,
                         metrics={"test_acc": acc, "test_margin": marg})
         print(f"Done RM. test_acc {acc:.3f} margin {marg:.3f} -> {cfg.out_ckpt}")

--- a/scripts/train_sft.py
+++ b/scripts/train_sft.py
@@ -111,7 +111,10 @@ def main():
                             metrics={"train_loss": loss.item()})
 
     if ctx.is_main:
-        dev = eval_dev(model, cfg, ctx, DEV_PATH)
+        # Use the unwrapped model for the final eval: the other ranks have already reached
+        # cleanup(), so calling the DDP-wrapped model here would launch a collective with no
+        # peer and hang (NCCL timeout). The periodic eval above runs on all ranks, so it is fine.
+        dev = eval_dev(unwrap(model), cfg, ctx, DEV_PATH)
         save_stage_ckpt(cfg.out_ckpt, model, optimizer, stage="sft", cfg=cfg, step=total_steps,
                         metrics={"dev_loss": dev})
         print(f"Done SFT. dev_loss {dev:.4f} -> {cfg.out_ckpt}")

--- a/src/post_training/distributed.py
+++ b/src/post_training/distributed.py
@@ -58,16 +58,21 @@ def ddp_setup(device: str = "cuda") -> DDPContext:
     return DDPContext(rank=rank, local_rank=local_rank, world_size=world_size, device=dev)
 
 
-def ddp_wrap(model: torch.nn.Module, ctx: DDPContext) -> torch.nn.Module:
+def ddp_wrap(model: torch.nn.Module, ctx: DDPContext, find_unused_parameters: bool = False) -> torch.nn.Module:
     """Wrap a model in DDP when running multi-GPU; return it unchanged otherwise.
 
     Only the *trainable* model should be wrapped. Reference / old-policy / reward models
     carry no gradients and must NOT be wrapped (they are replicated identically per rank).
+
+    Pass ``find_unused_parameters=True`` for a model where some parameters do not receive a
+    gradient on every step (for example the reward model, which uses the backbone's
+    ``forward_hidden`` and a reward head but never its ``lm_head``). Without it, DDP raises
+    a "did not get a gradient" error on the first backward.
     """
     if not ctx.enabled:
         return model
     device_ids = [ctx.local_rank] if ctx.device.startswith("cuda") else None
-    return DDP(model, device_ids=device_ids, find_unused_parameters=False)
+    return DDP(model, device_ids=device_ids, find_unused_parameters=find_unused_parameters)
 
 
 def is_main_process(ctx: DDPContext) -> bool:


### PR DESCRIPTION
## Fix multi-GPU (DDP) training hangs

Three trainers crashed under `torchrun --nproc_per_node=2` (single-GPU was unaffected). Two distinct causes, both fixed here.

### 1. Final-eval NCCL hang (SFT, Reward, DPO)
After the training loop, the final evaluation runs only on rank 0 (`if ctx.is_main:`) but called the **DDP-wrapped** model's forward. That launches an NCCL collective with no peer (the other ranks have already reached `cleanup()`), so rank 0 waits out the 600s NCCL watchdog, aborts with SIGABRT, and leaves a **0-byte checkpoint**. Pretrain/PPO/GRPO never hit this (their last step is save-only and their eval uses `unwrap(...)`).

**Fix:** run the final eval on `unwrap(model)`. The periodic eval already runs on all ranks, so it is unchanged.

### 2. Reward model unused-parameter crash
`RewardModel` uses the backbone's `forward_hidden` + a scalar reward head and never its `lm_head`, so those params get no gradient and DDP (default `find_unused_parameters=False`) errors on the first backward.

**Fix:** add an optional `find_unused_parameters` flag to `ddp_wrap` (default `False`, so every other stage is unchanged) and pass `True` for the reward model.

### Verification
Ran all six trainers under `torchrun --nproc_per_node=2` on 2x L40 with the smoke configs (so the final eval, the failing path, actually runs). All complete and save valid checkpoints; `nvidia-smi` showed both GPUs working (peak GPU0 88% / GPU1 94%).

| Trainer | before | after |
|---|---|---|
| pretrain | ok | ok |
| sft | hang -> 0-byte | ok |
| reward | crash + hang | ok |
| dpo | hang -> 0-byte | ok |
| ppo | ok | ok |
| grpo | ok | ok |

Files: `src/post_training/distributed.py`, `scripts/train_sft.py`, `scripts/train_reward.py`, `scripts/train_dpo.py`.
