### PR TITLE
fix: restore the star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,4 +759,4 @@ Wanna chat on something? [My Linkedin](https://www.linkedin.com/in/fareed-khan-d
 
 ## Star History
 
-[![](https://api.star-history.com/svg?repos=FareedKhan-dev/train-llm-from-scratch&type=Date)](https://star-history.com/#FareedKhan-dev/train-llm-from-scratch&Date)
+[![](https://star-history.dera.page/svg?repos=FareedKhan-dev/train-llm-from-scratch&type=Date)](https://star-history.dera.page/#FareedKhan-dev/train-llm-from-scratch&Date)


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken and no longer renders, which is a shame for a 13M parameter training tutorial that people like to watch gain stars. This switches the chart to a working provider so the Star History section is visible again.